### PR TITLE
make Chunk class final

### DIFF
--- a/unxip.swift
+++ b/unxip.swift
@@ -80,7 +80,7 @@ struct ConcurrentStream<TaskResult: Sendable> {
 	}
 }
 
-class Chunk: Sendable {
+final class Chunk: Sendable {
 	let buffer: UnsafeBufferPointer<UInt8>
 	let owned: Bool
 


### PR DESCRIPTION
When building with `swiftc -parse-as-library -O unxip.swift` (Swift 5.5.2) I'm getting the following error

```
unxip.swift:83:7: error: non-final class 'Chunk' cannot conform to `Sendable`; use `@unchecked Sendable`
class Chunk: Sendable {
```

