### PR TITLE
Create Swift package to separate command-line tool from core functionality

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,9 @@
+.DS_Store
+/.build
+/Packages
+/*.xcodeproj
+xcuserdata/
+DerivedData/
+.swiftpm/config/registries.json
+.swiftpm/xcode/package.xcworkspace/contents.xcworkspacedata
+.netrc

--- a/Package.swift
+++ b/Package.swift
@@ -1,0 +1,16 @@
+// swift-tools-version: 5.5
+
+import PackageDescription
+
+let package = Package(
+	name: "unxip",
+	platforms: [.macOS(.v12)],
+	products: [
+		.executable(name: "unxip", targets: ["unxip"]),
+		.library(name: "UnxipFramework", targets: ["UnxipFramework"]),
+	],
+	targets: [
+		.executableTarget(name: "unxip", dependencies: ["UnxipFramework"]),
+		.target(name: "UnxipFramework"),
+	]
+)

--- a/Package.swift
+++ b/Package.swift
@@ -4,7 +4,7 @@ import PackageDescription
 
 let package = Package(
 	name: "unxip",
-	platforms: [.macOS(.v12)],
+	platforms: [.macOS(.v11)],
 	products: [
 		.executable(name: "unxip", targets: ["unxip"]),
 		.library(name: "UnxipFramework", targets: ["UnxipFramework"]),

--- a/README.md
+++ b/README.md
@@ -4,7 +4,13 @@ unxip is a command line-tool designed for rapidly unarchiving Xcode XIP files an
 
 ## Installation
 
-Not much installation is needed to use unxip: simply download unxip.swift and compile it using `swiftc -parse-as-library -O unxip.swift` to produce the `unxip` binary.
+Not much installation is needed to use unxip: simply clone the repository and build the executable target to produce the `unxip` binary.
+
+```bash
+swift build -c release
+sudo cp -f .build/release/unxip /usr/local/bin/unxip
+unxip -h
+```
 
 ## Usage
 

--- a/README.md
+++ b/README.md
@@ -4,18 +4,17 @@ unxip is a command line-tool designed for rapidly unarchiving Xcode XIP files an
 
 ## Installation
 
-Not much installation is needed to use unxip: simply clone the repository and build the executable target to produce the `unxip` binary in `.build/release`.
+Not much installation is needed to use unxip: simply clone the repository and build the executable target to produce an `unxip` binary in the `.build/release` directory.
 
-```bash
-swift build -c release
-.build/release/unxip -h
+```console
+$ git clone https://github.com/saagarjha/unxip.git && cd unxip
+$ swift build -c release
 ```
 
-Optionally, copy over the binary to your `/usr/local/bin` directory, which will include it in your `$PATH`.
+Copy it over to your `/usr/local/bin` directory if you'd like to include it in your `$PATH`.
 
-```bash
-sudo cp -f .build/release/unxip /usr/local/bin/unxip
-unxip -h
+```console
+$ sudo cp -f .build/release/unxip /usr/local/bin/unxip
 ```
 
 ## Usage

--- a/README.md
+++ b/README.md
@@ -4,10 +4,16 @@ unxip is a command line-tool designed for rapidly unarchiving Xcode XIP files an
 
 ## Installation
 
-Not much installation is needed to use unxip: simply clone the repository and build the executable target to produce the `unxip` binary.
+Not much installation is needed to use unxip: simply clone the repository and build the executable target to produce the `unxip` binary in `.build/release`.
 
 ```bash
 swift build -c release
+.build/release/unxip -h
+```
+
+Optionally, copy over the binary to your `/usr/local/bin` directory, which will include it in your `$PATH`.
+
+```bash
 sudo cp -f .build/release/unxip /usr/local/bin/unxip
 unxip -h
 ```

--- a/Sources/unxip/unxip.swift
+++ b/Sources/unxip/unxip.swift
@@ -1,0 +1,79 @@
+import Foundation
+import UnxipFramework
+
+extension option {
+	init(name: StaticString, has_arg: CInt, flag: UnsafeMutablePointer<CInt>?, val: StringLiteralType) {
+		let _option = name.withUTF8Buffer {
+			$0.withMemoryRebound(to: CChar.self) {
+				option(name: $0.baseAddress, has_arg: has_arg, flag: flag, val: CInt(UnicodeScalar(val)!.value))
+			}
+		}
+		self = _option
+	}
+}
+
+extension Unxip.Options {
+	static func fromCommandLine() -> Self {
+		let options = [
+			option(name: "compression-disable", has_arg: no_argument, flag: nil, val: "c"),
+			option(name: "help", has_arg: no_argument, flag: nil, val: "h"),
+			option(name: nil, has_arg: 0, flag: nil, val: 0),
+		]
+
+		var compress: Bool = true
+		var result: CInt
+		repeat {
+			result = getopt_long(CommandLine.argc, CommandLine.unsafeArgv, "ch", options, nil)
+			if result < 0 {
+				break
+			}
+			switch UnicodeScalar(UInt32(result)) {
+				case "c":
+					compress = false
+				case "h":
+					Self.printUsage(nominally: true)
+				default:
+					Self.printUsage(nominally: false)
+			}
+		} while true
+
+		let arguments = UnsafeBufferPointer(start: CommandLine.unsafeArgv + Int(optind), count: Int(CommandLine.argc - optind)).map {
+			String(cString: $0!)
+		}
+
+		guard let inputArgument = arguments.first else {
+			Self.printUsage(nominally: false)
+		}
+		let input = URL(fileURLWithPath: inputArgument)
+
+		let output: URL?
+		if let outputArgument = arguments.dropFirst().first {
+			output = URL(fileURLWithPath: outputArgument)
+		} else {
+			output = nil
+		}
+
+		return Self(input: input, output: output, compress: compress)
+	}
+
+	static func printUsage(nominally: Bool) -> Never {
+		fputs(
+			"""
+			A fast Xcode unarchiver
+
+			USAGE: unxip [options] <input> [output]
+
+			OPTIONS:
+			    -c, --compression-disable  Disable APFS compression of result.
+			    -h, --help                 Print this help message.
+			""", nominally ? stdout : stderr)
+		exit(nominally ? EXIT_SUCCESS : EXIT_FAILURE)
+	}
+}
+
+@main
+struct Main {
+	static func main() async throws {
+		try await Unxip.unxip(options: .fromCommandLine())
+	}
+}


### PR DESCRIPTION
`unxip` is very impressive, I've personally seen a 3x speed improvement on my machine when unxipping Xcode.

One use-case I have run into with `unxip` is wanting to use it from within any other tool or framework that needs to unxip something. With the current project structure, it meant copying over `unxip.swift` into such a project or including this repository as a git submodule.

A third option would be to create a Swift package around the core functionality of `unxip`, while still providing a quick way to build the command-line tool as well through an [`executableTarget`](https://github.com/apple/swift-evolution/blob/main/proposals/0294-package-executable-targets.md). This PR achieves such an option.

I've tried to preserve the original structure of the code as much as possible, while trying my best to separate the concerns of the command-line tool from the core functionality. I'm using it over at my fork and wanted to open this pull request to see if you'd support this direction too. 😄 

One caveat is that it has made the installation process a little more complicated, but we could publish a [Homebrew formula](https://docs.brew.sh/Formula-Cookbook) to turn it back into one command, i.e. `brew install unxip`.