### PR TITLE
Add a barebone makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,2 @@
+all:
+	swiftc -parse-as-library -O unxip.swift


### PR DESCRIPTION
Mostly because it's faster than reading the Readme to find the compilation command ... 