### PR TITLE
Makefile: Add format rule

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-PREFIX		?= /usr/local
+PREFIX ?= /usr/local
 
 .PHONY: all
 all: unxip
@@ -9,7 +9,7 @@ unxip: unxip.swift
 .PHONY: clean
 clean:
 	rm unxip
-	
+
 .PHONY: install
 install:
 	install unxip $(PREFIX)/bin/
@@ -17,3 +17,7 @@ install:
 .PHONY: uninstall
 uninstall:
 	rm $(PREFIX)/bin/unxip
+
+.PHONY: format
+format:
+	swift-format -i *.swift


### PR DESCRIPTION
Due to the Makefile consolidating the building, installing, and removal of the project, I thought it'd be best to also include a rule that simply runs `swift-format`.

The changes to the source code of the project were made after running the Makefile rule, which I thought I'd also commit here, as well as document the rule over the command that it runs on the README.