### PR TITLE
Package.swift: Exclude more files in target

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -16,6 +16,8 @@ let package = Package(
 			exclude: [
 				"LICENSE",
 				"README.md",
+				"release.sh",
+				"Makefile"
 			],
 			sources: ["unxip.swift"]
 		)

--- a/Package.swift
+++ b/Package.swift
@@ -17,7 +17,7 @@ let package = Package(
 				"LICENSE",
 				"README.md",
 				"release.sh",
-				"Makefile"
+				"Makefile",
 			],
 			sources: ["unxip.swift"]
 		)


### PR DESCRIPTION
This change resolves the following warning, which shows up when using the Swift Package Manager to build `unxip`.

```console
warning: 'unxip': found 2 file(s) which are unhandled; explicitly declare them as resources or exclude from the target
    ~/Projects/unxip/release.sh
    ~/Projects/unxip/Makefile
```