### PR TITLE
CI: Only trigger on actual code changes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,11 +2,21 @@ name: CI
 
 on:
   push:
+    paths:
+      - '*.swift'
+      - 'Makefile'
+      - '.github/workflows/*'
   pull_request:
-      branches: [master]
+    paths:
+      - '*.swift'
+      - 'Makefile'
+      - '.github/workflows/*'
+    branches:
+      - master
 
 jobs:
-  test:
+  build:
+    name: Build
     runs-on: macos-12
     environment: ci
     steps:
@@ -27,9 +37,9 @@ jobs:
       - name: Run unxip
         run: .build/release/unxip Xcode_14.0.1.xip
 
-        # diff on Monterey is gnudiff, which exits with EXIT_TROUBLE (2) if it
-        # finds problems. The Xcode bundle has a ruby symlink that is recursive,
-        # which trips this. So don't rely on the status, but instead use the
-        # output exclusively.
+        # diff on Monterey is gnudiff, which exits with EXIT_TROUBLE (2) if
+        # it finds problems. The Xcode bundle has a Ruby symlink that is
+        # recursive, which trips this. So don't rely on the status, but
+        # instead use the output exclusively.
       - name: Validate Xcode
         run: diff -r Xcode.app /Applications/Xcode_14.0.1.app > diff || true; cat diff && ! test -s diff

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,15 +12,16 @@ on:
       - 'Makefile'
       - '.github/workflows/*'
     branches:
-      - master
+      - main
 
 jobs:
-  build:
-    name: Build
+  test:
+    name: Test
     runs-on: macos-12
     environment: ci
     steps:
-      - uses: actions/checkout@v2
+      - name: Checkout
+        uses: actions/checkout@v3
 
       - name: Download Xcode
         run: wget http://server.saagarjha.com/Xcode_14.0.1.xip.encrypted
@@ -37,9 +38,9 @@ jobs:
       - name: Run unxip
         run: .build/release/unxip Xcode_14.0.1.xip
 
-        # diff on Monterey is gnudiff, which exits with EXIT_TROUBLE (2) if
-        # it finds problems. The Xcode bundle has a Ruby symlink that is
-        # recursive, which trips this. So don't rely on the status, but
-        # instead use the output exclusively.
+        # diff on Monterey is gnudiff, which exits with EXIT_TROUBLE (2) if it
+        # finds problems. The Xcode bundle has a ruby symlink that is recursive,
+        # which trips this. So don't rely on the status, but instead use the
+        # output exclusively.
       - name: Validate Xcode
         run: diff -r Xcode.app /Applications/Xcode_14.0.1.app > diff || true; cat diff && ! test -s diff


### PR DESCRIPTION
CI builds should only trigger if actual code changes have been made (in any branch or in any PR made to `main`, not `master`) - that is, if a file directly affecting the functionality and building of the project changes.

Also, Github will completely deprecate Node12-based actions (see: [this GH blog post](https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/)), so it's best to upgrade all used actions to their latest versions to prevent the CI from breaking.