### PR TITLE
make AsyncThrowingStream extension init public

### DIFF
--- a/unxip.swift
+++ b/unxip.swift
@@ -151,7 +151,7 @@ extension AsyncThrowingStream where Failure == Error {
 		}
 	}
 
-	init<S: AsyncSequence>(erasing sequence: S) where S.Element == Element {
+	public init<S: AsyncSequence>(erasing sequence: S) where S.Element == Element {
 		var iterator = sequence.makeAsyncIterator()
 		self.init {
 			try await iterator.next()


### PR DESCRIPTION
When using `AsyncThrowingStream` similar to how the CLI works, I get errors with the following code: 

```swift
let handle: FileHandle
handle = try FileHandle(forReadingFrom: input)
        
let file = AsyncThrowingStream(erasing: DataReader.data(readingFrom: handle.fileDescriptor))
```
returns `Cannot convert value of type 'AsyncThrowingStream<[UInt8], any Error>' to expected argument type '() async throws -> Element?'`

