### PR TITLE
Support building with the Android (bionic) Swift toolchain

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -4,6 +4,25 @@ import PackageDescription
 #if os(macOS)
 	let dependencies = [Target.Dependency]()
 	let systemLibraries = [Target]()
+#elseif os(Android)
+	// The Android NDK modulemap already provides the zlib and getopt
+	// modules, so defining our own would clash. GNUSource and lzma
+	// still need shims.
+	let dependencies: [Target.Dependency] = [
+		.target(name: "GNUSource"),
+		.target(name: "lzma"),
+	]
+	let systemLibraries: [Target] = [
+		.systemLibrary(
+			name: "GNUSource"
+		),
+		.systemLibrary(
+			name: "lzma",
+			providers: [
+				.aptItem(["liblzma-dev"])
+			]
+		),
+	]
 #else
 	let dependencies: [Target.Dependency] = [
 		.target(name: "GNUSource"),

--- a/Package.swift
+++ b/Package.swift
@@ -1,56 +1,44 @@
 // swift-tools-version:6.0
 import PackageDescription
 
-#if os(macOS)
-	let dependencies = [Target.Dependency]()
-	let systemLibraries = [Target]()
-#elseif os(Android)
-	// The Android NDK modulemap already provides the zlib and getopt
-	// modules, so defining our own would clash. GNUSource and lzma
-	// still need shims.
-	let dependencies: [Target.Dependency] = [
-		.target(name: "GNUSource"),
-		.target(name: "lzma"),
-	]
-	let systemLibraries: [Target] = [
-		.systemLibrary(
-			name: "GNUSource"
-		),
-		.systemLibrary(
-			name: "lzma",
-			providers: [
-				.aptItem(["liblzma-dev"])
-			]
-		),
-	]
-#else
-	let dependencies: [Target.Dependency] = [
-		.target(name: "GNUSource"),
-		.target(name: "getopt"),
-		.target(name: "zlib"),
-		.target(name: "lzma"),
-	]
-	let systemLibraries: [Target] = [
-		.systemLibrary(
-			name: "GNUSource"
-		),
-		.systemLibrary(
-			name: "getopt"
-		),
-		.systemLibrary(
-			name: "lzma",
-			providers: [
-				.aptItem(["liblzma-dev"])
-			]
-		),
-		.systemLibrary(
-			name: "zlib",
-			providers: [
-				.apt(["zlib1g-dev"])
-			]
-		),
-	]
-#endif
+// Platform conditions are modelled with .when rather than #if so they
+// are evaluated for the TARGET platform, not the manifest host — this
+// keeps cross compilation (e.g. Linux/Android from a macOS host, or
+// Android from Linux) selecting the right dependencies. The system
+// library shim targets are declared unconditionally: targets that end
+// up unreferenced for a platform are not built, so their modulemaps
+// cannot clash with platform-provided modules.
+let dependencies: [Target.Dependency] = [
+	// glibc/Bionic both need the GNUSource and lzma shims; macOS and
+	// iOS-family SDKs provide the needed functionality directly.
+	.target(name: "GNUSource", condition: .when(platforms: [.linux, .android])),
+	.target(name: "lzma", condition: .when(platforms: [.linux, .android])),
+	// The Android NDK already ships zlib and getopt modules, so these
+	// shims are Linux-only.
+	.target(name: "getopt", condition: .when(platforms: [.linux])),
+	.target(name: "zlib", condition: .when(platforms: [.linux])),
+]
+
+let systemLibraries: [Target] = [
+	.systemLibrary(
+		name: "GNUSource"
+	),
+	.systemLibrary(
+		name: "getopt"
+	),
+	.systemLibrary(
+		name: "lzma",
+		providers: [
+			.aptItem(["liblzma-dev"])
+		]
+	),
+	.systemLibrary(
+		name: "zlib",
+		providers: [
+			.apt(["zlib1g-dev"])
+		]
+	),
+]
 
 let package = Package(
 	name: "unxip",

--- a/Sources/GNUSource/gnusource.h
+++ b/Sources/GNUSource/gnusource.h
@@ -1,11 +1,2 @@
 #define _GNU_SOURCE
 #include <fcntl.h>
-
-#ifdef __BIONIC__
-#include <sys/types.h>
-
-// Swift cannot import the variadic openat(); provide a fixed-arity wrapper.
-static inline int unxip_openat(int fd, const char *path, int flags, mode_t mode) {
-	return openat(fd, path, flags, mode);
-}
-#endif

--- a/Sources/GNUSource/gnusource.h
+++ b/Sources/GNUSource/gnusource.h
@@ -1,8 +1,11 @@
 #define _GNU_SOURCE
-#include <sys/types.h>
 #include <fcntl.h>
+
+#ifdef __BIONIC__
+#include <sys/types.h>
 
 // Swift cannot import the variadic openat(); provide a fixed-arity wrapper.
 static inline int unxip_openat(int fd, const char *path, int flags, mode_t mode) {
 	return openat(fd, path, flags, mode);
 }
+#endif

--- a/Sources/GNUSource/gnusource.h
+++ b/Sources/GNUSource/gnusource.h
@@ -1,2 +1,8 @@
 #define _GNU_SOURCE
+#include <sys/types.h>
 #include <fcntl.h>
+
+// Swift cannot import the variadic openat(); provide a fixed-arity wrapper.
+static inline int unxip_openat(int fd, const char *path, int flags, mode_t mode) {
+	return openat(fd, path, flags, mode);
+}

--- a/unxip.swift
+++ b/unxip.swift
@@ -2,6 +2,12 @@
 	@preconcurrency import SwiftGlibc  // stdout, stderr
 #else
 	@preconcurrency import unistd  // optind
+	#if canImport(cpio)
+		import cpio  // C_ISREG, C_ISDIR, C_ISLNK, C_ISVTX, MAGIC
+	#endif
+	#if canImport(Android)
+		@preconcurrency import Android  // SIG_IGN, stdout, stderr
+	#endif
 #endif
 import Foundation
 
@@ -1282,7 +1288,12 @@ public enum Files: StreamAperture {
 								}
 
 								let fd = measureFilesystemOperation(on: file, named: "open") {
-									openat(options.output, file.name, O_CREAT | O_WRONLY, mode_t(file.mode & 0o777))
+									#if os(Android)
+										// bionic's openat() is variadic and unavailable to Swift; use the GNUSource shim.
+										unxip_openat(options.output, file.name, O_CREAT | O_WRONLY, mode_t(file.mode & 0o777))
+									#else
+										openat(options.output, file.name, O_CREAT | O_WRONLY, mode_t(file.mode & 0o777))
+									#endif
 								}
 								if fd < 0 {
 									warn(fd, "creating file at")
@@ -1310,7 +1321,7 @@ public enum Files: StreamAperture {
 									repeat {
 										written = data.withUnsafeBytes { data in
 											measureFilesystemOperation(on: file, named: "pwrite") {
-												pwrite(fd, data.baseAddress, data.count, off_t(position))
+												pwrite(fd, data.baseAddress!, data.count, off_t(position))
 											}
 										}
 										if written < 0 {
@@ -1430,8 +1441,14 @@ extension AsyncSequence where Element: Sendable, AsyncIterator: Sendable, Self: 
 					Self.options.map {
 						option(name: $0.name, has_arg: no_argument, flag: nil, val: $0.flag)
 					} + [option(name: nil, has_arg: 0, flag: nil, val: 0)]
+				#if os(Android)
+					// bionic's getopt_long takes non-optional argv pointers
+					let argv = UnsafePointer(UnsafeRawPointer(CommandLine.unsafeArgv).assumingMemoryBound(to: UnsafeMutablePointer<CChar>.self))
+				#else
+					let argv = CommandLine.unsafeArgv
+				#endif
 				repeat {
-					let result = getopt_long(CommandLine.argc, CommandLine.unsafeArgv, Self.options.map(\.flag).reduce("", +), options, nil)
+					let result = getopt_long(CommandLine.argc, argv, Self.options.map(\.flag).reduce("", +), options, nil)
 					guard result >= 0 else {
 						break
 					}
@@ -1528,7 +1545,7 @@ extension AsyncSequence where Element: Sendable, AsyncIterator: Sendable, Self: 
 					watchedSignal = SIGINFO
 				#else
 					watchedSignal = SIGUSR1
-					signal(watchedSignal, SIG_IGN)
+					_ = signal(watchedSignal, SIG_IGN)
 				#endif
 
 				let source = DispatchSource.makeSignalSource(signal: watchedSignal)

--- a/unxip.swift
+++ b/unxip.swift
@@ -1288,12 +1288,7 @@ public enum Files: StreamAperture {
 								}
 
 								let fd = measureFilesystemOperation(on: file, named: "open") {
-									#if os(Android)
-										// bionic's openat() is variadic and unavailable to Swift; use the GNUSource shim.
-										unxip_openat(options.output, file.name, O_CREAT | O_WRONLY, mode_t(file.mode & 0o777))
-									#else
-										openat(options.output, file.name, O_CREAT | O_WRONLY, mode_t(file.mode & 0o777))
-									#endif
+									openat(options.output, file.name, O_CREAT | O_WRONLY, mode_t(file.mode & 0o777))
 								}
 								if fd < 0 {
 									warn(fd, "creating file at")


### PR DESCRIPTION
This lets unxip build natively on Android with the Swift Android toolchain (e.g. under Termux), where the C library is bionic rather than Glibc. All changes are additive and guarded, so existing platforms are unaffected; I verified the package builds and `unxip --help` runs on-device (aarch64).

Changes:
- **Package.swift**: the Android NDK modulemap already provides `zlib` and `getopt` modules, so defining our own shims errors out with duplicate module definitions. On Android, only `GNUSource` and `lzma` shims are kept. (Like the existing `#if os(macOS)` check, this relies on the manifest running on the host, so it applies to native builds.)
- **gnusource.h**: new `unxip_openat()` fixed-arity wrapper — Swift cannot import bionic's variadic `openat()`.
- **unxip.swift**:
  - `import cpio` (for `C_ISREG`/`MAGIC`/etc.) and `@preconcurrency import Android` (for `SIG_IGN`, and to keep `stdout`/`stderr` concurrency-safe-importable) where those modules exist.
  - Use the `unxip_openat()` shim on Android.
  - bionic's `pwrite()` takes a non-optional buffer pointer (`data.baseAddress!`), `getopt_long()` takes non-optional argv pointers, and `signal()` is marked `warn_unused_result` (`_ =`).